### PR TITLE
Add manual trigger to the Trivy workflow

### DIFF
--- a/.github/workflows/trivy-scan.yml
+++ b/.github/workflows/trivy-scan.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     branches:
       - '**'
+  workflow_dispatch:
 
 jobs:
   trivy-scan:
@@ -26,4 +27,9 @@ jobs:
         sudo apt-get install -y trivy
 
     - name: Run Trivy scan
-      run: trivy fs --exit-code 1 --severity HIGH,CRITICAL .
+      id: trivy-scan
+      run: trivy fs --exit-code 1 --severity HIGH,CRITICAL . | tee trivy-report.txt
+
+    - name: Display Trivy scan results
+      if: always()
+      run: cat trivy-report.txt

--- a/README.md
+++ b/README.md
@@ -87,3 +87,17 @@ The purpose of this workflow is to ensure that the project is free from known vu
 ## How to use
 
 The workflow is triggered automatically on push and pull request events. It downloads and runs the Aqua Security Trivy tool to scan the project for vulnerabilities. The results of the scan are displayed in the GitHub Actions tab.
+
+## Automated Trigger
+
+The Trivy GitHub Action workflow is now automatically triggered for new branches and when a pull request is opened or edited. This ensures that every new branch and pull request is scanned for vulnerabilities.
+
+## Output Format
+
+The Trivy GitHub Action workflow outputs the scan results and vulnerabilities in the following format:
+
+- **Severity**: The severity level of the vulnerability (e.g., HIGH, CRITICAL).
+- **Package Name**: The name of the package that contains the vulnerability.
+- **Installed Version**: The version of the package that is currently installed.
+- **Fixed Version**: The version of the package that contains the fix for the vulnerability.
+- **Description**: A brief description of the vulnerability.


### PR DESCRIPTION
Add manual trigger to the Trivy workflow and output scan results.

* Modify `.github/workflows/trivy-scan.yml` to add a manual trigger for the Trivy GitHub Action workflow.
* Add steps to output the scan results and vulnerabilities in the action run.
* Update `README.md` to mention the automated trigger for new branches and PRs.
* Add a section in `README.md` specifying the output format for the Trivy scan results and vulnerabilities.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/wzhdard/spring-boot-realworld-example-app/pull/1?shareId=12e897fd-3986-4e7f-8cbe-5a1c6e09cb5c).