### PR TITLE
Print Trivy scan results in action run logs

### DIFF
--- a/.github/workflows/trivy-scan.yml
+++ b/.github/workflows/trivy-scan.yml
@@ -28,8 +28,8 @@ jobs:
 
     - name: Run Trivy scan
       id: trivy-scan
-      run: trivy fs --exit-code 1 --severity HIGH,CRITICAL . | tee trivy-report.txt
+      run: trivy fs --exit-code 1 --severity HIGH,CRITICAL --format json . | tee trivy-report.json
 
     - name: Display Trivy scan results
       if: always()
-      run: cat trivy-report.txt
+      run: cat trivy-report.json

--- a/README.md
+++ b/README.md
@@ -101,3 +101,9 @@ The Trivy GitHub Action workflow outputs the scan results and vulnerabilities in
 - **Installed Version**: The version of the package that is currently installed.
 - **Fixed Version**: The version of the package that contains the fix for the vulnerability.
 - **Description**: A brief description of the vulnerability.
+
+## Viewing Trivy Scan Results
+
+To view the Trivy scan results in the action run logs, the workflow includes a step to display the contents of the `trivy-report.txt` file. This file contains the detailed output of the scan results.
+
+The `cat trivy-report.txt` command is used to output the contents of the `trivy-report.txt` file directly in the action run logs. This allows you to see the exact result of the Trivy scan for the application.


### PR DESCRIPTION
Modify the GitHub Actions workflow to print the exact Trivy scan results in the action run logs.

* **README.md**
  - Add a section to explain how to view the Trivy scan results in the action run logs.
  - Mention the `cat trivy-report.txt` command and its purpose.

* **.github/workflows/trivy-scan.yml**
  - Modify the `Run Trivy scan` step to output the results in JSON format.
  - Modify the `Display Trivy scan results` step to include the `cat trivy-report.json` command.
  - Ensure the `Display Trivy scan results` step runs even if the previous steps fail.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/wzhdard/spring-boot-realworld-example-app/pull/2?shareId=8f51f741-3390-41d6-9b2a-c119c7140f83).